### PR TITLE
feat: Allow specifying health check request paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,4 +131,5 @@ You can configure the script using the following environment variables:
 | server port     | HEALTHCHECK_PORT      | 9999, the same as the default port of healthCheckServer |
 | server host     | HEALTHCHECK_HOST      | localhost                                               |
 | request timeout | HEALTHCHECK_TIMEOUT   | 50000 milliseconds                                      |
+| request path    | HEALTHCHECK_PATH      | /                                                       |
 

--- a/bin/check.js
+++ b/bin/check.js
@@ -6,11 +6,13 @@ const {
 	HEALTHCHECK_PORT = 9999,
 	HEALTHCHECK_HOST = 'localhost',
 	HEALTHCHECK_TIMEOUT = 5000, // In milliseconds
+	HEALTHCHECK_PATH = '/',
 } = process.env;
 
 const options = {
 	host: HEALTHCHECK_HOST,
 	port: HEALTHCHECK_PORT,
+	path: HEALTHCHECK_PATH,
 	timeout: HEALTHCHECK_TIMEOUT,
 };
 


### PR DESCRIPTION
By default, the health check binary uses the path `/`. This commit allows specifying a different path like `/health/check`.

noissue